### PR TITLE
Fix: world.addEventHandler() takes Lua table, not a function

### DIFF
--- a/dcs-world-schema/globals/world.singleton.yaml
+++ b/dcs-world-schema/globals/world.singleton.yaml
@@ -5,19 +5,19 @@ globals:
     addedVersion: "1.2.0"
     static:
       addEventHandler:
-        description: "Registers a function to be called when simulator events occur. Different event types produce different event data structures."
+        description: "Registers an event handler table to be called when simulator events occur. The table must contain an onEvent method."
         params:
           - name: handler
-            type: function
-            description: "The event handler function. The function signature should be `function(eventData)` where eventData is of type EventData, which is a union of all possible event data types. The id field identifies which type of event is being handled."
+            type: EventHandlerTable
+            description: "A table containing an onEvent method that will be called with event data when events occur."
         returns: nil
         addedVersion: "1.2.0"
       removeEventHandler:
-        description: "Unregisters a previously added event handler function."
+        description: "Unregisters a previously added event handler table."
         params:
           - name: handler
-            type: function
-            description: "The event handler function to remove."
+            type: EventHandlerTable
+            description: "The event handler table to remove. Must be the same table that was passed to addEventHandler."
         returns: nil
         addedVersion: "1.2.0"
       onEvent:

--- a/dcs-world-schema/types/Event.types.yaml
+++ b/dcs-world-schema/types/Event.types.yaml
@@ -74,7 +74,15 @@ types:
       TgtPlayerName:
         type: string | nil
         description: "Name of the player that was targeted."
-      
+
+  EventHandlerTable:
+    kind: record
+    description: "Defines the structure of a Lua table representing an event handler object that can be registered with world.addEventHandler."
+    fields:
+      onEvent:
+        type: function
+        description: "Function that handles simulator events when they occur. Called with (self, event) parameters where event is of type EventData."
+
   EventDataBase:
     kind: record
     description: "Base structure for all event data. Contains common fields present in every event."


### PR DESCRIPTION
… (#13)

- Add EventHandlerTable type to define the expected table structure with onEvent method
- Update world.addEventHandler() to accept EventHandlerTable instead of function
- Update world.removeEventHandler() to accept EventHandlerTable instead of function
- Fix function descriptions to accurately reflect DCS World API behavior

The functions now correctly expect a table containing an onEvent method rather than a direct function parameter.